### PR TITLE
Fixed empty string(s) at the end of CString

### DIFF
--- a/cstrings.go
+++ b/cstrings.go
@@ -9,11 +9,12 @@ import (
 const NULL = "\x00"
 
 /* DecodeCStrings splits c style strings into golang slice */
-func DecodeCStrings(data []byte) []string {
+func DecodeCStrings(data []byte) (str []string) {
 	if len(data) == 0 {
 		return nil
 	}
-	return strings.Split(strings.Trim(string(data), NULL), NULL)
+	str = strings.Split(string(data), NULL)
+	return str[:len(str) - 1]
 }
 
 /* ReadCString reads and returs c style string from []byte */


### PR DESCRIPTION
Fix to correct decode C strings with empty at tail. For example:
"foo\0bar\0baz\0\0" -> ["foo", "bar", "baz", ""]