### PR TITLE
Fixed session disconnection

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -7,6 +7,10 @@ import (
 
 // Milter is an interface for milter callback handlers
 type Milter interface {
+	// Init is called on begin of a new Mail (before Connect() and after Body() )
+	// Can be used to Reset session state to before SMFIC_MAIL
+	Init()
+
 	// Connect is called to provide SMTP connection data for incoming message
 	//   supress with NoConnect
 	Connect(host string, family string, port uint16, addr net.IP, m *Modifier) (Response, error)
@@ -38,4 +42,7 @@ type Milter interface {
 	// Body is called at the end of each message
 	//   all changes to message's content & attributes must be done here
 	Body(m *Modifier) (Response, error)
+
+	// Disconnect is called at the end of the message Handling loop
+	Disconnect()
 }


### PR DESCRIPTION
Added Init() and Disconnect() to the interface.

Init() which is called before the first mail and after the end-of-body, and also on RSET (abort command), so you can cleanup and init.

Disconnect() which is called when the client disconnects (if you have a concurrent session counter you can decrease the counter there, this was not possible before)

this fixes #7

Also fixes Handling if the milter rejects only some rcpts (not all), in the previous implementation the milter disconnects the session on a single rcpt rejected.

The disconnect behaviour now follows this: https://github.com/phalaaxx/milter/blob/master/milter-protocol.txt#L137

Tested Init() with postfix and "RSET" during a session, and also with end of body.