### PR TITLE
fix(ipv6): Fix ipv6 parsing

### DIFF
--- a/session.go
+++ b/session.go
@@ -128,6 +128,9 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 			}
 			Port = binary.BigEndian.Uint16(msg.Data)
 			msg.Data = msg.Data[2:]
+			if protocolFamily == '6' {
+				msg.Data = msg.Data[5:] // ipv6 is in format IPv6:XXX:XX1
+			}
 		}
 		// get address
 		Address := readCString(msg.Data)


### PR DESCRIPTION
IPv6 address is returned like "IPv6:2001:db8::1428:57ab"
So trim this prefix is needed