### PR TITLE
Add SMFIC_ABORT and SMFIC_QUIT callbacks

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -38,4 +38,12 @@ type Milter interface {
 	// Body is called at the end of each message
 	//   all changes to message's content & attributes must be done here
 	Body(m *Modifier) (Response, error)
+
+	// Abort is called with SMFIC_ABORT
+	//   Abort current filter checks
+	Abort()
+
+	// Quit is called with SMFIC_QUIT
+	//   Quit milter communication
+	Quit()
 }

--- a/interface.go
+++ b/interface.go
@@ -41,9 +41,9 @@ type Milter interface {
 
 	// Abort is called with SMFIC_ABORT
 	//   Abort current filter checks
-	Abort(m *Modifier)
+	Abort()
 
 	// Quit is called with SMFIC_QUIT
 	//   Quit milter communication
-	Quit(m *Modifier)
+	Quit()
 }

--- a/interface.go
+++ b/interface.go
@@ -41,9 +41,9 @@ type Milter interface {
 
 	// Abort is called with SMFIC_ABORT
 	//   Abort current filter checks
-	Abort()
+	Abort(m *Modifier)
 
 	// Quit is called with SMFIC_QUIT
 	//   Quit milter communication
-	Quit()
+	Quit(m *Modifier)
 }

--- a/session.go
+++ b/session.go
@@ -107,6 +107,7 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		// abort current message and start over
 		m.headers = nil
 		m.macros = nil
+		m.milter.Abort()
 		// do not send response
 		return nil, nil
 
@@ -212,6 +213,7 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		return NewResponse('O', buffer.Bytes()), nil
 
 	case 'Q':
+		m.milter.Quit()
 		// client requested session close
 		return nil, errCloseSession
 

--- a/session.go
+++ b/session.go
@@ -104,10 +104,13 @@ func (m *milterSession) WritePacket(msg *Message) error {
 func (m *milterSession) Process(msg *Message) (Response, error) {
 	switch msg.Code {
 	case 'A':
+		defer func() {
+			if r := recover(); r != nil {
+				println(r)
+			}
+		}()
 		// abort current message and start over
-		if m.milter.Abort != nil {
-			m.milter.Abort(newModifier(m))
-		}
+		m.milter.Abort(newModifier(m))
 		m.headers = nil
 		m.macros = nil
 		// do not send response
@@ -215,9 +218,12 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		return NewResponse('O', buffer.Bytes()), nil
 
 	case 'Q':
-		if m.milter.Quit != nil {
-			m.milter.Quit(newModifier(m))
-		}
+		defer func() {
+			if r := recover(); r != nil {
+				println(r)
+			}
+		}()
+		m.milter.Quit(newModifier(m))
 		// client requested session close
 		return nil, errCloseSession
 

--- a/session.go
+++ b/session.go
@@ -105,9 +105,11 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 	switch msg.Code {
 	case 'A':
 		// abort current message and start over
+		if m.milter.Abort != nil {
+			m.milter.Abort(newModifier(m))
+		}
 		m.headers = nil
 		m.macros = nil
-		m.milter.Abort()
 		// do not send response
 		return nil, nil
 
@@ -213,7 +215,9 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		return NewResponse('O', buffer.Bytes()), nil
 
 	case 'Q':
-		m.milter.Quit()
+		if m.milter.Quit != nil {
+			m.milter.Quit(newModifier(m))
+		}
 		// client requested session close
 		return nil, errCloseSession
 

--- a/session.go
+++ b/session.go
@@ -104,13 +104,13 @@ func (m *milterSession) WritePacket(msg *Message) error {
 func (m *milterSession) Process(msg *Message) (Response, error) {
 	switch msg.Code {
 	case 'A':
-		defer func() {
-			if r := recover(); r != nil {
-				println(r)
-			}
+		func() {
+			defer func() {
+				if r := recover(); r != nil { }
+			}()
+			m.milter.Abort()
 		}()
 		// abort current message and start over
-		m.milter.Abort(newModifier(m))
 		m.headers = nil
 		m.macros = nil
 		// do not send response
@@ -218,12 +218,12 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		return NewResponse('O', buffer.Bytes()), nil
 
 	case 'Q':
-		defer func() {
-			if r := recover(); r != nil {
-				println(r)
-			}
+		func() {
+			defer func() {
+				if r := recover(); r != nil { }
+			}()
+			m.milter.Quit()
 		}()
-		m.milter.Quit(newModifier(m))
 		// client requested session close
 		return nil, errCloseSession
 

--- a/session.go
+++ b/session.go
@@ -108,7 +108,7 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 			defer func() {
 				if r := recover(); r != nil { }
 			}()
-			m.milter.Abort()
+			m.milter.Abort(newModifier(m))
 		}()
 		// abort current message and start over
 		m.headers = nil
@@ -222,7 +222,7 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 			defer func() {
 				if r := recover(); r != nil { }
 			}()
-			m.milter.Quit()
+			m.milter.Quit(newModifier(m))
 		}()
 		// client requested session close
 		return nil, errCloseSession


### PR DESCRIPTION
For some milters it is important to have a callback for SMFIC_ABORT and/or SMFIC_QUIT. Example: To check which callbacks had run, you can evaluate this at Qui() and do things like updating a database or logging information, etc.